### PR TITLE
Support Python stdlib logging

### DIFF
--- a/eslog/log.py
+++ b/eslog/log.py
@@ -81,5 +81,8 @@ class Logger():
     def warn(self, msg, **kwargs):
         self._logger.warn(msg, **dict(kwargs))
 
+    def warning(self, msg, **kwargs):
+        self._logger.warning(msg, **dict(kwargs))
+
     def error(self, msg, **kwargs):
         self._logger.error(msg, **dict(kwargs))

--- a/eslog/log.py
+++ b/eslog/log.py
@@ -2,6 +2,7 @@ import collections
 import os
 from datetime import datetime
 
+import structlog
 from structlog import (
         PrintLogger,
         wrap_logger,
@@ -11,27 +12,55 @@ from structlog.processors import (
 )
 
 
+USE_STDLIB = bool(os.getenv("ESLOG_USE_STDLIB"))
+
+
 def order_fields(_, level, event_dict):
 
     response = collections.OrderedDict()
     response['level'] = level
-    response['message'] = event_dict.pop('message')
+    response['message'] = event_dict.pop('event')
     response['timestamp'] = datetime.utcnow().strftime("%Y-%m-%dT%H:%M:%SZ")
 
     response.update(sorted(event_dict.items()))
     return response
 
 
+if USE_STDLIB:
+    structlog.configure(
+        processors=[
+            structlog.stdlib.ProcessorFormatter.wrap_for_formatter,
+        ],
+        logger_factory=structlog.stdlib.LoggerFactory(),
+    )
+
+
 class Logger():
 
     def __init__(self, output=None, service=None, namespace=None):
 
-        log = wrap_logger(
-                PrintLogger(output),
-                processors=[
-                    order_fields,
-                    JSONRenderer(),
-                ])
+        if USE_STDLIB:
+            log = structlog.getLogger(
+               processors=[
+                   structlog.stdlib.filter_by_level,
+                   structlog.stdlib.add_logger_name,
+                   structlog.stdlib.add_log_level,
+                   structlog.stdlib.PositionalArgumentsFormatter(),
+                   structlog.processors.StackInfoRenderer(),
+                   structlog.processors.format_exc_info,
+                   structlog.processors.UnicodeDecoder(),
+                   structlog.stdlib.render_to_log_kwargs,
+               ],
+               context_class=dict,
+               wrapper_class=structlog.stdlib.BoundLogger,
+            )
+        else:
+            log = wrap_logger(
+                    PrintLogger(output),
+                    processors=[
+                        order_fields,
+                        JSONRenderer(),
+                    ])
 
         if service is None:
             self._service = os.getenv('SERVICE_NAME', '')
@@ -44,13 +73,13 @@ class Logger():
             self._logger = self._logger.bind(namespace=namespace)
 
     def debug(self, msg, **kwargs):
-        self._logger.debug(**dict(kwargs, message=msg))
+        self._logger.debug(msg, **dict(kwargs))
 
     def info(self, msg, **kwargs):
-        self._logger.info(**dict(kwargs, message=msg))
+        self._logger.info(msg, **dict(kwargs))
 
     def warn(self, msg, **kwargs):
-        self._logger.warn(**dict(kwargs, message=msg))
+        self._logger.warn(msg, **dict(kwargs))
 
     def error(self, msg, **kwargs):
-        self._logger.error(**dict(kwargs, message=msg))
+        self._logger.error(msg, **dict(kwargs))


### PR DESCRIPTION
We have project using json logging configurations for the standard library. They use libraries that in turn use pyeslog.

This PR suggests adding a configuration option (environment variable) that configures pyeslog to not do any output formatting but instead just use pythons standard library and thereby allow uniform log handling in a project that wants to control it's own logging.

Should be backwards compatible, please verify! There are a lot of applications that use the master branch of this repo.